### PR TITLE
opset_version alread specified in DEFAULT_EXPORT (util.py)

### DIFF
--- a/clip_onnx/clip_converter.py
+++ b/clip_onnx/clip_converter.py
@@ -36,7 +36,7 @@ class clip_converter(nn.Module):
             self.textual_path = model_quant_textual
 
     def torch_export(self, model, dummy_input, path: str, export_params=DEFAULT_EXPORT):
-        torch.onnx.export(model, dummy_input, path, opset_version=12, **export_params)
+        torch.onnx.export(model, dummy_input, path, **export_params)
 
     def onnx_checker(self, path: str):
         model = onnx.load(path)


### PR DESCRIPTION
Fixes
```
TypeError: export() got multiple values for keyword argument 'opset_version'
```